### PR TITLE
Make INSTALL_DIR overridable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,13 @@
 set -euo pipefail
 
 PWD=$(pwd)
-INSTALL_DIR=/usr/local/bin
 LOCAL_JAR_PATH=$PWD/target/default+uberjar
 LOCAL_JAR_NAME=atoss-cli-standalone.jar
 LOCAL_JAR_FILE=$LOCAL_JAR_PATH/$LOCAL_JAR_NAME
+
+if [ -z ${INSTALL_DIR+x} ]; then
+  INSTALL_DIR=/usr/local/bin
+fi
 
 # Make a check that chromedriver and java are present
 echo 'Checking requirements...'
@@ -32,6 +35,7 @@ fi
 
 echo "Installing wrapper..."
 
-cp -f "$PWD/wrapper.sh" "${INSTALL_DIR}/atoss-cli"
+sed "s|INSTALL_DIR=.*|INSTALL_DIR=$INSTALL_DIR|" "$PWD/wrapper.sh" > "${INSTALL_DIR}/atoss-cli"
+chmod 755 "$INSTALL_DIR/atoss-cli"
 
 echo "Done! You can try running atoss-cli --version"

--- a/install.sh
+++ b/install.sh
@@ -28,9 +28,9 @@ if [ -f "$LOCAL_JAR_FILE" ]; then
 	install "$LOCAL_JAR_FILE" "$INSTALL_DIR"
 else
 	echo "$LOCAL_JAR_FILE does not exist, pulling latest release from Github."
-	mkdir -p $LOCAL_JAR_PATH
-	curl -L https://github.com/platogo/atoss-cli/releases/latest/download/atoss-cli-standalone.jar > $LOCAL_JAR_FILE
-	install $LOCAL_JAR_FILE $INSTALL_DIR
+	mkdir -p "$LOCAL_JAR_PATH"
+	curl -L https://github.com/platogo/atoss-cli/releases/latest/download/atoss-cli-standalone.jar > "$LOCAL_JAR_FILE"
+	install "$LOCAL_JAR_FILE" $INSTALL_DIR
 fi
 
 echo "Installing wrapper..."

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 PWD=$(pwd)
-LOCAL_JAR_FILE=$PWD/target/default+uberjar/atoss-cli-standalone.jar
 INSTALL_DIR=/usr/local/bin
+LOCAL_JAR_PATH=$PWD/target/default+uberjar
+LOCAL_JAR_NAME=atoss-cli-standalone.jar
+LOCAL_JAR_FILE=$LOCAL_JAR_PATH/$LOCAL_JAR_NAME
 
 # Make a check that chromedriver and java are present
 echo 'Checking requirements...'
@@ -23,8 +25,9 @@ if [ -f "$LOCAL_JAR_FILE" ]; then
 	install "$LOCAL_JAR_FILE" "$INSTALL_DIR"
 else
 	echo "$LOCAL_JAR_FILE does not exist, pulling latest release from Github."
-	curl -L https://github.com/platogo/atoss-cli/releases/latest/download/atoss-cli-standalone.jar >atoss-cli-standalone.jar
-	install atoss-cli-standalone.jar $INSTALL_DIR
+	mkdir -p $LOCAL_JAR_PATH
+	curl -L https://github.com/platogo/atoss-cli/releases/latest/download/atoss-cli-standalone.jar > $LOCAL_JAR_FILE
+	install $LOCAL_JAR_FILE $INSTALL_DIR
 fi
 
 echo "Installing wrapper..."

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 JAR_NAME="atoss-cli-standalone.jar"
+INSTALL_DIR=/usr/local/bin
 
 # This is a simple bash wrapper around the JAR that passes down args to the Java launcher.
 
-java -jar /usr/local/bin/$JAR_NAME "$@"
+java -jar $INSTALL_DIR/$JAR_NAME "$@"


### PR DESCRIPTION
So I can run `INSTALL_DIR=~/.bin ./install.sh`