### PR TITLE
Fix not found chrome binary error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject atoss-cli "0.3.5-SNAPSHOT"
+(defproject atoss-cli "0.3.6-SNAPSHOT"
   :description "A CLI tool for interacting with ATOSS time sheets"
   :url "https://github.com/platogo/atoss-cli"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/atoss_cli/atoss.clj
+++ b/src/atoss_cli/atoss.clj
@@ -20,6 +20,9 @@
 
 (def update-btn {:css ".z-toolbarbutton:nth-of-type(1)"})
 (def date-input {:css ".z-datebox-input"})
+(def timepair-table {:css "div.slick-pane.slick-pane-top.slick-pane-left > div.slick-viewport.slick-viewport-top.slick-viewport-left"})
+(def time-pair-row {:css "div.slick-row"})
+(def add-time-pair-btn {:css "ul.z-menupopup-content > li.z-menuitem > a.z-menuitem-content:first-of-type"})
 
 (defprotocol TimeSheetDay
   (fmt-row [day]))
@@ -75,9 +78,9 @@
 
 (defn setup-driver
   "Create a default driver instance to be used for interacting with ATOSS. Headless by default."
-  ([] (setup-driver true))
-  ([headless?]
-   (let [driver (api/chrome {:headless headless?})]
+  ([] (setup-driver {:headless true}))
+  ([opts]
+   (let [driver (api/chrome opts)]
      (api/set-window-size driver 1200 800)
      driver)))
 

--- a/src/atoss_cli/core.clj
+++ b/src/atoss_cli/core.clj
@@ -31,10 +31,12 @@
         (green "Logged time for date: " date))
        (shutdown-agents))
 
-      (catch Exception e (-> e
+      (catch Exception e 
+        (-> e
                              (.getMessage)
                              (red)
-                             (println))))))
+                             (println))
+        (atoss/end driver)))))
 
 (defn web
   "Open in web browser."

--- a/src/atoss_cli/core.clj
+++ b/src/atoss_cli/core.clj
@@ -10,10 +10,21 @@
   (:import (java.util Collection))
   (:gen-class))
 
+
+(def mac-chrome-path "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
+
+(defn -maybe-inject-mac-chrome-path
+  "Inject the path to the Chrome binary on macOS if the current OS is macOS."
+  [opts]
+  (let [os-name (System/getProperty "os.name")]
+    (if (re-find #"Mac OS X" os-name)
+      (assoc opts :path-browser mac-chrome-path)
+      opts)))
+
 (defn log-time
   "Log a time pair for a given date."
   [{opts :options}]
-  (let [driver (atoss/setup-driver)
+  (let [driver (atoss/setup-driver (-maybe-inject-mac-chrome-path {:headless true}))
         config (config/load-in)
         {date :date} opts
         session-opts (merge opts config)]
@@ -31,11 +42,11 @@
         (green "Logged time for date: " date))
        (shutdown-agents))
 
-      (catch Exception e 
+      (catch Exception e
         (-> e
-                             (.getMessage)
-                             (red)
-                             (println))
+            (.getMessage)
+            (red)
+            (println))
         (atoss/end driver)))))
 
 (defn web


### PR DESCRIPTION
Seems with Chrome 115, something change with the binary name, and the driver can't find it automatically anymore.